### PR TITLE
Added timeout to validation

### DIFF
--- a/src/Ehesp/SteamLogin/SteamLogin.php
+++ b/src/Ehesp/SteamLogin/SteamLogin.php
@@ -60,7 +60,7 @@ class SteamLogin implements SteamLoginInterface
      *
      * @return string
      */
-    public function validate()
+    public function validate($timeout = 30)
     {
         $response = null;
 
@@ -92,6 +92,7 @@ class SteamLogin implements SteamLoginInterface
                     "Content-Length: " . strlen($data) . "\r\n",
                     'content' => $data,
                     ),
+                'timeout' => $timeout
             ));
 
             $result = file_get_contents(self::$openId, false, $context);


### PR DESCRIPTION
Steam's OpenID endpoint can sometimes slow down or die completely. On high-traffic sites this can pretty much grind the site to a halt from so many requests to Steam eating up 60 seconds (the default on file_get_contents) for every request.

So I've added a timeout option with a default of 20 (which should be plenty to get a request from Steam unless its down)