### PR TITLE
bindShared has been removed in Laravel 5.2

### DIFF
--- a/src/Ehesp/SteamLogin/Laravel/SteamLoginServiceProvider.php
+++ b/src/Ehesp/SteamLogin/Laravel/SteamLoginServiceProvider.php
@@ -13,7 +13,7 @@ class SteamLoginServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bindShared('steamlogin', function($app) {
+        $this->app->singleton('steamlogin', function($app) {
             return new SteamLogin();
         });
     }


### PR DESCRIPTION
Updated my application to Laravel 5.2 and I've been jumping through hoops figuring out a bunch of issues. It seems `bindShared` has now been completely removed from 5.2