### PR TITLE
Moved timeout to within http array block

### DIFF
--- a/src/Ehesp/SteamLogin/SteamLogin.php
+++ b/src/Ehesp/SteamLogin/SteamLogin.php
@@ -91,8 +91,8 @@ class SteamLogin implements SteamLoginInterface
                     "Content-type: application/x-www-form-urlencoded\r\n" .
                     "Content-Length: " . strlen($data) . "\r\n",
                     'content' => $data,
+                    'timeout' => $timeout
                     ),
-                'timeout' => $timeout
             ));
 
             $result = file_get_contents(self::$openId, false, $context);


### PR DESCRIPTION
Either it was in the wrong place to begin with but didn't throw an error, or it's been moved in newer PHP versions, but the timeout now throws an error with this PR fixes.